### PR TITLE
fix: runtime error when running command from parsed config properties

### DIFF
--- a/.github/actions/setup-dev-environment/action.yml
+++ b/.github/actions/setup-dev-environment/action.yml
@@ -1,0 +1,10 @@
+name: Setup development environment 
+description: Setup runner to be able to use deno. 
+
+runs:
+  using: "composite"
+  steps:
+  - uses: actions/checkout@v4
+  - uses: denoland/setup-deno@v1
+    with:
+      deno-version: v1.x

--- a/.github/actions/setup-dev-environment/action.yml
+++ b/.github/actions/setup-dev-environment/action.yml
@@ -4,7 +4,6 @@ description: Setup runner to be able to use deno.
 runs:
   using: "composite"
   steps:
-  - uses: actions/checkout@v4
   - uses: denoland/setup-deno@v1
     with:
       deno-version: v1.x

--- a/.github/workflows/deploy-binary.yml
+++ b/.github/workflows/deploy-binary.yml
@@ -16,11 +16,8 @@ jobs:
     permissions:
       contents: write # to be able to push git tags and create github releases
     steps: 
-      - uses: actions/checkout@v4
-      - uses: denoland/setup-deno@v1
-        with:
-          deno-version: v1.x
-
+      - uses: ./.github/actions/setup-dev-environment
+    
       - name: Compile script into a macOS m1 binary 
         run: |
           deno compile --allow-all --target aarch64-apple-darwin binny.ts

--- a/.github/workflows/deploy-binary.yml
+++ b/.github/workflows/deploy-binary.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       contents: write # to be able to push git tags and create github releases
     steps: 
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-dev-environment
     
       - name: Compile script into a macOS m1 binary 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,12 +3,16 @@ name: Tests
 on: [pull_request]
 
 jobs: 
+  run-automated-tests:
+    runs-on: ubuntu-latest
+    steps: 
+      - uses: ./.github/actions/setup-dev-environment
+      - name: Run automated tests 
+        run: deno test
+
   test-script-can-compile: 
     runs-on: ubuntu-latest
     steps: 
-      - uses: actions/checkout@v4
-      - uses: denoland/setup-deno@v1
-        with:
-          deno-version: v1.x
+      - uses: ./.github/actions/setup-dev-environment
       - name: Compile script into a macOS m1 binary 
         run: deno compile --allow-all --target aarch64-apple-darwin binny.ts

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,7 @@ jobs:
   run-automated-tests:
     runs-on: ubuntu-latest
     steps: 
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-dev-environment
       - name: Run automated tests 
         run: deno test
@@ -13,6 +14,7 @@ jobs:
   test-script-can-compile: 
     runs-on: ubuntu-latest
     steps: 
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-dev-environment
       - name: Compile script into a macOS m1 binary 
         run: deno compile --allow-all --target aarch64-apple-darwin binny.ts

--- a/binny.ts
+++ b/binny.ts
@@ -11,67 +11,47 @@
  * If you want to update the version of a tool to a newer version, simply update the version number in the toolsUsedInProject array below and push a commit to the repo. Then, all developers and CI servers will automatically download the new version the next time they execute this script.
  * 
  * This script is written in TypeScript and uses Deno as the runtime. In order to execute this script, you need to have Deno installed (brew install deno), or we can compile this script into a binary and run it that way.
- * Command to run this script: deno run --allow-net --allow-read --allow-write --allow-run binny.ts swiftlint --strict 
- * Command to compile this script into a binary: make compile_run_tool
  */
 
-interface Tool {
-  name: string;
-  version: string;
-  downloadUrl: string;
-  pathToBinaryInsideZip: string;
-
-  [propName: string]: string // added to allow the interface to work with stringFormat(). Fixes error, "Index signature for type 'string' is missing in type 'Tool'"
-}
-
 import {existsSync as doesFileExist } from "https://deno.land/std@0.201.0/fs/mod.ts";
-import { format as stringFormat } from "https://deno.land/x/format@1.0.1/mod.ts";
 import { decompress as unzip } from "https://deno.land/x/zip@v1.2.5/mod.ts";
 import {parse as parseYaml} from "https://deno.land/std@0.201.0/yaml/mod.ts";
+import { ToolConfig, Tool } from "./types/tool.ts";
 
 const nameOfToolToRun = Deno.args[0] // get the name of the tool to run from the command line arguments. Example value: 'swiftlint'
-const toolsUsedInProject: Tool[] = parseYaml(Deno.readTextFileSync("binny-tools.yml")) as Tool[]; // Read binny-tools.yml file which is used to define what tools are used in this project.
-const tool: Tool = toolsUsedInProject.find(tool => tool.name === nameOfToolToRun)!
+const toolsUsedInProject: ToolConfig[] = parseYaml(Deno.readTextFileSync("binny-tools.yml")) as ToolConfig[]; // Read binny-tools.yml file which is used to define what tools are used in this project.
+const tool: Tool = new Tool(toolsUsedInProject.find(tool => tool.name === nameOfToolToRun)!)
 
-const rootPathToTool = await assertToolInstalled()
-await runCommand(rootPathToTool)
+await assertToolInstalled()
+await runCommand()
 
-async function assertToolInstalled(): Promise<string> {
-  Deno.mkdirSync("./tools", { recursive: true }); // make the tools directory in case it does not exist. This is where all the tools will be installed
-
-  // This is the file path where we expect the tool to be installed. Each tool has it's own unique directory within the tools/ directory. It's also important to version the directory so that 
-  // the tool can download newer versions if needed. 
-  const toolInstallLocation = `./tools/${tool.name}_${tool.version}`; 
+async function assertToolInstalled(): Promise<void> {
+  Deno.mkdirSync(tool.relativeInstallLocationPath, { recursive: true }); // make the tools directory in case it does not exist. This is where all the tools will be installed
 
   // Check if we have already installed the tool. 
-  if (doesFileExist(toolInstallLocation, { isDirectory: true })) {
-    // Tool exists.
-    return toolInstallLocation
+  if (doesFileExist(tool.relativeInstallLocationPath, { isDirectory: true })) {
+    // Tool exists, quit early.
+    return
   }
 
   // Tool does not exist so it must be installed. 
   // Each tool gets downloaded from GitHub as a zip file. We need to download the zip file and then unzip the file into a specific directory. Once it is unzipped, we consider the tool installed. 
   console.log(`${tool.name} is not yet installed or is out-of-date. Installing ${tool.name}, version: ${tool.version}...`)
-  
-  const downloadZipUrl = stringFormat(tool.downloadUrl, tool); // the download URL is dynamic. Use string format to inject variables into the download URL string to get a versioned URL for the zip file. 
+    
   const downloadedZipFilePath = `/tmp/${tool.name}_${tool.version}.zip`; // We save the tool into the /tmp directory as we do not need it after we unzip the file.   
   
   // download zip file into the /tmp directory
-  const response = await fetch(downloadZipUrl); 
+  const response = await fetch(tool.downloadZipUrl); 
   Deno.writeFileSync(downloadedZipFilePath, new Uint8Array(await response.arrayBuffer()));
 
   // unzip the file into the tools directory. 
-  await unzip(downloadedZipFilePath, toolInstallLocation);
+  await unzip(downloadedZipFilePath, tool.relativeInstallLocationPath);
 
   console.log(`Downloaded ${tool.name}, version ${tool.version}`);
-
-  return toolInstallLocation
 }
 
-// rootPathToTool - example: ./tools/swiftlint_0.39.2 where the tool will be located inside of this given directory. 
-async function runCommand(rootPathToTool: string) {
-  const command = `${rootPathToTool}/${tool.commandToRun}` // example result: ./tools/sourcery_0.39.2/bin/sourcery which is the full path to the binary to execute 
+async function runCommand() {
   const argsToSendToCommand = Deno.args.slice(1); // remove the first argument as it is the name of the tool to run. But we allow passing other args to the command. 
 
-  await new Deno.Command(command, { args: argsToSendToCommand, stdout: "inherit", stderr: "inherit" }).output();
+  await new Deno.Command(tool.commandToExecuteBinary, { args: argsToSendToCommand, stdout: "inherit", stderr: "inherit" }).output();
 }

--- a/types/tool.ts
+++ b/types/tool.ts
@@ -1,0 +1,33 @@
+import { format as stringFormat } from "https://deno.land/x/format@1.0.1/mod.ts";
+
+// After parsing binny-tools.yml, we get an array of ToolConfig objects with this shape. 
+export interface ToolConfig {
+  name: string;
+  version: string;
+  downloadUrl: string;
+  pathToBinaryInsideZip: string;
+}
+
+// Turn the ToolConfig into a an object with useful properties for the rest of the script.
+export class Tool {
+  name: string;
+  version: string;
+
+  // example: `./tools/sourcery_0.39.2` which is the path to the directory where the tool is installed.
+  relativeInstallLocationPath: string;
+  downloadZipUrl: string
+  // example: `./tools/sourcery_0.39.2/bin/sourcery` which is the full path to the binary to execute 
+  commandToExecuteBinary: string 
+
+  constructor(config: ToolConfig) {
+    this.name = config.name;
+    this.version = config.version;
+
+    // This is the file path where we expect the tool to be installed. Each tool has it's own unique directory within the tools/ directory. It's also important to version the directory so that 
+    // the tool can download newer versions if needed. 
+    this.relativeInstallLocationPath = `./tools/${this.name}_${this.version}`;
+    // downloadUrl has dynamic placeholders inside of it.
+    this.downloadZipUrl = stringFormat(config.downloadUrl, this as any)
+    this.commandToExecuteBinary = `${this.relativeInstallLocationPath}/${config.pathToBinaryInsideZip}`
+  }
+}

--- a/types/tool_test.ts
+++ b/types/tool_test.ts
@@ -6,14 +6,14 @@ Deno.test("Tool, expect constructor to populate properties with expected values"
     name: "swiftlint",
     version: "0.39.2",
     relativeInstallLocationPath: "./tools/swiftlint_0.39.2",
-    downloadZipUrl: "https://github.com/krzysztofzablocki/Sourcery/releases/download/0.39.2/sourcery-0.39.2.zip",
+    downloadZipUrl: "https://github.com/realm/SwiftLint/releases/download/0.39.2/portable_swiftlint.zip",
     commandToExecuteBinary: "./tools/swiftlint_0.39.2/bin/swiftlint",
   }
 
   const actual: Tool = new Tool({
     name: "swiftlint",
     version: "0.39.2",
-    downloadUrl: "https://github.com/krzysztofzablocki/Sourcery/releases/download/{version}/sourcery-{version}.zip",
+    downloadUrl: "https://github.com/realm/SwiftLint/releases/download/{version}/portable_swiftlint.zip",
     pathToBinaryInsideZip: "bin/swiftlint",
   })
   

--- a/types/tool_test.ts
+++ b/types/tool_test.ts
@@ -1,0 +1,21 @@
+import { assertObjectMatch } from "https://deno.land/std@0.201.0/assert/mod.ts";
+import { Tool } from "./tool.ts";
+
+Deno.test("Tool, expect constructor to populate properties with expected values", () => {
+  const expected: Tool = {
+    name: "swiftlint",
+    version: "0.39.2",
+    relativeInstallLocationPath: "./tools/swiftlint_0.39.2",
+    downloadZipUrl: "https://github.com/krzysztofzablocki/Sourcery/releases/download/0.39.2/sourcery-0.39.2.zip",
+    commandToExecuteBinary: "./tools/swiftlint_0.39.2/bin/swiftlint",
+  }
+
+  const actual: Tool = new Tool({
+    name: "swiftlint",
+    version: "0.39.2",
+    downloadUrl: "https://github.com/krzysztofzablocki/Sourcery/releases/download/{version}/sourcery-{version}.zip",
+    pathToBinaryInsideZip: "bin/swiftlint",
+  })
+  
+  assertObjectMatch(actual, expected as any);
+});


### PR DESCRIPTION
I ran into a runtime exception when using tool today. The script was trying to use `tool.commandToRun`, but that is no longer a property that is used in `binny-tools.yml` config objects. 

This PR fixes that runtime exception by using `tool.pathToBinaryInsideZip`, but also adds automated tests to make sure that this doesn't happen again. 

I had to perform a refactor of moving interfaces into it's own files in order to create automated tests. I'll add comments to this PR trying to help understand what was copy/pasted and what is new code. 