### PR TITLE
feat: add macOS x64 binaries to deployment

### DIFF
--- a/.github/workflows/deploy-binary.yml
+++ b/.github/workflows/deploy-binary.yml
@@ -23,6 +23,11 @@ jobs:
         run: |
           deno compile --allow-all --target aarch64-apple-darwin binny.ts
           mv binny binny-macos-m1
+
+      - name: Compile script into a macOS x64 binary 
+        run: |
+          deno compile --allow-all --target x86_64-apple-darwin binny.ts
+          mv binny binny-macos-x86_64
       
       - name: Compile script into a Linux binary 
         run: |
@@ -32,7 +37,7 @@ jobs:
       - name: Create a git tag 'latest' and a GitHub release 'latest' to attach compiled binary to. 
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "binny-macos-m1,binny-linux-x86_64" # upload these binary files to the release so team members can easily download it. 
+          artifacts: "binny-macos-m1,binny-linux-x86_64,binny-macos-x86_64" # upload these binary files to the release so team members can easily download it. 
           tag: "latest" # create a git tag 'latest'
           commit: "main" # create a git tag 'latest' from the latest commit on the main branch 
           allowUpdates: true # if 'latest' release already exists, update it. 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
         run: deno test --allow-all # provide all permissions to the test script because it modifies file system to prepare for e2e tests. 
 
   test-script-compiles-and-runs: 
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps: 
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-dev-environment


### PR DESCRIPTION
Right now, our iOS SDK CI server runs binny on Linux OS instead of macOS. I wanted to try to make the iOS SDK CI run on Linux instead of macOS because Linux is faster, but [it doesn't work](https://github.com/customerio/customerio-ios/actions/runs/7452320766/job/20275317836?pr=470). I believe this is because the tools that binny executes (lint, formatter) are iOS tools and not may work on Linux. 

To try and fix our iOS SDK CI, I [ran an experiment](https://github.com/customerio/customerio-ios/actions/runs/7477383566/job/20349926338?pr=474) of seeing if we run binny on macOS machines instead of Linux, it would fix the issue. It did fix it!

This PR makes binny make macOS x64 builds instead of just m1 builds. These new mac builds will be used by the iOS SDK's CI server. 

After this PR is merged, another PR will be made on iOS SDK to start running binny on macOS. 