### PR TITLE
fix: if command binny runs fails, binny should also fail

### DIFF
--- a/src/e2e_test.ts
+++ b/src/e2e_test.ts
@@ -15,3 +15,16 @@ Deno.test("run binny with a real tool, expect it runs command", async () => {
 
   assertEquals(actualStdout, expectedStdout)
 })
+
+Deno.test("binny should fail if the command that it executes also fails", async () => {
+  let didThrowError = false
+
+  // We want binny to successfully run the swiftlint binary, but the swiftlint binary should fail when it executes. 
+  try {
+    await runTool("swiftlint", ["--typo-to-make-command-fail"], "binny-tools.yml")
+  } catch {
+    didThrowError = true
+  }
+
+  assertEquals(didThrowError, true)
+})

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -21,10 +21,15 @@ export async function runTool(nameOfToolToRun: string, commandArgsForToolToRun: 
 
 async function runCommand(tool: Tool, commandArgsForToolToRun: string[]): Promise<string> {
   // piping the stdout to allow us to capture it into a variable that we then return from the function. 
-  const output = await new Deno.Command(tool.commandToExecuteBinary, { args: commandArgsForToolToRun, stdout: "piped", stderr: "inherit" }).output();
+  const { code, stdout } = await new Deno.Command(tool.commandToExecuteBinary, { args: commandArgsForToolToRun, stdout: "piped", stderr: "inherit" }).output();
 
-  const outputString = new TextDecoder().decode(output.stdout); // convert the output from a Uint8Array to a string.
+  const outputString = new TextDecoder().decode(stdout); // convert the output from a Uint8Array to a string.
   console.log(outputString) // print the output to the console so the user can see it.
+
+  if (code !== 0) { // if a bash command exits with a non-zero exit code, it means that it failed to run successfully.
+    console.error(`Running command: ${tool.commandToExecuteBinary} ${commandArgsForToolToRun}, failed executing with exit code ${code}.`)
+    Deno.exit(1) // binny should fail if the command that it runs also fails to match the behavior that the user expects.
+  }
 
   return outputString
 }


### PR DESCRIPTION
I ran a test in the iOS SDK's CI server. I purposely tried to make the linter fail. [The test was unsuccessful where binny executed, found the lint error, but binny succeeded](https://github.com/customerio/customerio-ios/actions/runs/7478914443/job/20354929365?pr=474). 

Binny's job is to run a command. So, it is expected that binny fails running if the command that it ran also failed. That's what this PR fixes. 

This will fix our SDK's CI server so when a lint check fails, the CI status check fails (expected). 