### PR TITLE
DX-516: Pin actions to SHA

### DIFF
--- a/.github/actions/setup-dev-environment/action.yml
+++ b/.github/actions/setup-dev-environment/action.yml
@@ -4,6 +4,6 @@ description: Setup runner to be able to use deno.
 runs:
   using: "composite"
   steps:
-  - uses: denoland/setup-deno@v1
+  - uses: denoland/setup-deno@11b63cf76cfcafb4e43f97b6cad24d8e8438f62d # v1.5.2
     with:
       deno-version: v1.x

--- a/.github/workflows/deploy-binary.yml
+++ b/.github/workflows/deploy-binary.yml
@@ -35,7 +35,7 @@ jobs:
           mv binny binny-linux-x86_64
 
       - name: Create a git tag 'latest' and a GitHub release 'latest' to attach compiled binary to. 
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # v1.16.0
         with:
           artifacts: "binny-macos-m1,binny-linux-x86_64,binny-macos-x86_64" # upload these binary files to the release so team members can easily download it. 
           tag: "latest" # create a git tag 'latest'


### PR DESCRIPTION
This PR pins GitHub Actions to SHA hashes instead of tags.